### PR TITLE
ios bugfix: Resizing now preserves the original aspect ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "cordova-plugin-image-resizer",
+  "version": "0.1.1",
+  "description": "Plugin for resizing images only with the uri of the image.",
+  "cordova": {
+    "id": "info.protonet.imageresizer",
+    "platforms": [
+      "ios",
+      "android"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JoschkaSchulz/cordova-plugin-image-resizer"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-ios",
+    "cordova-android"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.5.0"
+    }
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/JoschkaSchulz/cordova-plugin-image-resizer/issues"
+  },
+  "homepage": "https://github.com/JoschkaSchulz/cordova-plugin-image-resizer#readme"
+}

--- a/src/ios/ImageResizer.m
+++ b/src/ios/ImageResizer.m
@@ -53,7 +53,6 @@ static NSInteger count = 0;
     
     UIImage *tempImage = nil;
     CGSize targetSize = frameSize;
-    UIGraphicsBeginImageContext(targetSize);
     
     CGRect thumbnailRect = CGRectMake(0, 0, 0, 0);
     thumbnailRect.origin = CGPointMake(0.0,0.0);
@@ -78,7 +77,10 @@ static NSInteger count = 0;
     
     thumbnailRect.size.width  = newWidth;
     thumbnailRect.size.height = newHeight;
-
+    targetSize.width = newWidth;
+    targetSize.height = newHeight;
+    
+    UIGraphicsBeginImageContext(targetSize);
     [sourceImage drawInRect:thumbnailRect];
 
     tempImage = UIGraphicsGetImageFromCurrentImageContext();

--- a/src/ios/ImageResizer.m
+++ b/src/ios/ImageResizer.m
@@ -49,16 +49,35 @@ static NSInteger count = 0;
 
     }];
 
-    NSLog(@"image resizer:%@",  (sourceImage  ? @"image exsist" : @"null" ));
-
+    NSLog(@"image resizer:%@",  (sourceImage  ? @"image exists" : @"null" ));
+    
     UIImage *tempImage = nil;
     CGSize targetSize = frameSize;
     UIGraphicsBeginImageContext(targetSize);
-
+    
     CGRect thumbnailRect = CGRectMake(0, 0, 0, 0);
     thumbnailRect.origin = CGPointMake(0.0,0.0);
-    thumbnailRect.size.width  = targetSize.width;
-    thumbnailRect.size.height = targetSize.height;
+
+    // get original image dimensions
+    CGFloat heightInPoints = sourceImage.size.height;
+    CGFloat heightInPixels = heightInPoints * sourceImage.scale;
+    CGFloat widthInPoints = sourceImage.size.width;
+    CGFloat widthInPixels = widthInPoints * sourceImage.scale;
+    
+    // calculate the target dimensions in a way that preserves the original aspect ratio
+    CGFloat newWidth = targetSize.width;
+    CGFloat newHeight = targetSize.height;
+    
+    if (heightInPixels > widthInPixels) {
+        // vertical image: use targetSize.height as reference for scaling
+        newWidth = widthInPixels * newHeight / heightInPixels;
+    } else {
+        // horizontal image: use targetSize.width as reference
+        newHeight = heightInPixels * newWidth / widthInPixels;
+    }
+    
+    thumbnailRect.size.width  = newWidth;
+    thumbnailRect.size.height = newHeight;
 
     [sourceImage drawInRect:thumbnailRect];
 


### PR DESCRIPTION
Contrary to the expected behavior from the Android version, the iOS version won't preserve the aspect ratio.

Since currently there's no easy way to get image dimensions with Cordova (it requires to load the full image, and with new cameras, loading 16MB+ pictures takes a memory toll on Cordova apps), users cannot manually set these dimensions.

With this bugfix, the resizing will try to adhere to the original aspect ratio as much as possible, while respecting the user's provided settings.

Notice that it's impossible now to change the aspect ratio of the image; this might be the preferred behavior for this plugin.