### PR TITLE
Removes using localCacheFolder

### DIFF
--- a/src/windows/ImageResizerProxy.js
+++ b/src/windows/ImageResizerProxy.js
@@ -56,8 +56,6 @@
 
                     var fileContent = canvas.toDataURL(file.contentType).split(',')[1];
 
-                    var storageFolder = getAppData().localCacheFolder;
-
                     storageFolder.createFileAsync(tempPhotoFileName, OptUnique)
                         .then(function (storagefile) {
                             var content = Windows.Security.Cryptography.CryptographicBuffer.decodeFromBase64String(fileContent);


### PR DESCRIPTION
Removes **localCacheFolder** and uses **localfolder** instead. localcachefolder does not support ms-appdata uri ex **"ms-appdata:///local/"**

The current implementation is broken as the uri returned is invalid.