### PR TITLE
Oprion to rotate images based on EXIF data, and Base64 implementation for Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,8 @@
     </config-file>
 
     <source-file src="src/android/ImageResizer.java" target-dir="src/info/protonet/imageresizer" />
+	<preference name="ANDROID_EXIFINTERFACES_VERSION" default="27.+"/>
+	<framework src="com.android.support:exifinterface:$ANDROID_EXIFINTERFACES_VERSION"/>
   </platform>
 
   <platform name="ios">

--- a/src/android/ImageResizer.java
+++ b/src/android/ImageResizer.java
@@ -3,6 +3,8 @@ package info.protonet.imageresizer;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Environment;
 import android.util.Log;
@@ -29,6 +31,7 @@ public class ImageResizer extends CordovaPlugin {
     private int quality;
     private int width;
     private int height;
+    private boolean fixRotation = false;
 
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         try {
@@ -51,11 +54,28 @@ public class ImageResizer extends CordovaPlugin {
                 quality = jsonObject.getInt("quality");
                 width = jsonObject.getInt("width");
                 height = jsonObject.getInt("height");
+                if(jsonObject.has("fixRotation")){
+                  fixRotation = jsonObject.getBoolean("fixRotation");
+                }
 
                 // load the image from uri
                 Bitmap bitmap = loadScaledBitmapFromUri(uri, width, height);
 
-                // save the image as jpeg on the device
+                if(fixRotation){
+                  int rotation = getRoationDegrees(getRotation(uri));
+                  Matrix matrix = new Matrix();
+                  if (rotation != 0f) {matrix.preRotate(rotation);}
+                  bitmap = Bitmap.createBitmap(
+                    bitmap,
+                    0,
+                    0,
+                    bitmap.getWidth(),
+                    bitmap.getHeight(),
+                    matrix,
+                    true);
+                }
+
+              // save the image as jpeg on the device
                 Uri scaledFile = saveFile(bitmap);
 
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, scaledFile.toString()));
@@ -69,6 +89,34 @@ public class ImageResizer extends CordovaPlugin {
         }
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR));
         return false;
+    }
+
+    /**
+    * Gets the image rotation from the image EXIF Data
+    *
+    * @param exifOrientation ExifInterface.ORIENTATION_* representation of the rotation
+    * @return the rotation in degrees
+    */
+    private int getRoationDegrees(int exifOrientation){
+      if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90) { return 90; }
+      else if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_180) {  return 180; }
+      else if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_270) {  return 270; }
+      return 0;
+    }
+
+    /**
+    * Gets the image rotation from the image EXIF Data
+    *
+    * @param uriString the URI of the image to get the rotation for
+    * @return ExifInterface.ORIENTATION_* representation of the rotation
+    */
+    private int getRotation(String uriString){
+      try {
+        ExifInterface exif = new ExifInterface(uriString);
+        return exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+      } catch (IOException e) {
+        return ExifInterface.ORIENTATION_NORMAL;
+      }
     }
 
     /**

--- a/src/ios/ImageResizer.h
+++ b/src/ios/ImageResizer.h
@@ -2,4 +2,5 @@
 #import <Photos/Photos.h>
 @interface ImageResizer : CDVPlugin
 - (void) resize:(CDVInvokedUrlCommand*)command;
+- (UIImage*) rotateImage:(UIImage*) image withRotation:(int) rotation;
 @end

--- a/src/ios/ImageResizer.m
+++ b/src/ios/ImageResizer.m
@@ -29,12 +29,32 @@ static NSInteger count = 0;
     NSString* fileName = [arguments objectForKey:@"fileName"];
 
     BOOL asBase64 = [[arguments objectForKey:@"base64"] boolValue];
+    BOOL fixRotation = [[arguments objectForKey:@"fixRotation"] boolValue];
 
     //    //Get the image from the path
     NSURL* imageURL = [NSURL URLWithString:imageUrlString];
 
     sourceImage = [UIImage imageWithData: [NSData dataWithContentsOfURL: imageURL]];
-
+    
+    int rotation = 0;
+    
+    switch ([sourceImage imageOrientation]) {
+        case UIImageOrientationUp:
+            rotation = 0;
+            break;
+        case UIImageOrientationDown:
+            rotation = 180;
+            break;
+        case UIImageOrientationLeft:
+            rotation = 270;
+            break;
+        case UIImageOrientationRight:
+            rotation = 90;
+            break;
+        default:
+            break;
+    }
+    
     PHFetchResult *savedAssets = [PHAsset fetchAssetsWithLocalIdentifiers:@[fileName] options:nil];
     [savedAssets enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger idx, BOOL *stop) {
         //this gets called for every asset from its localIdentifier you saved
@@ -87,6 +107,10 @@ static NSInteger count = 0;
 
     tempImage = UIGraphicsGetImageFromCurrentImageContext();
     NSLog(@"image resizer:%@",  (tempImage  ? @"image exsist" : @"null" ));
+    
+    if(fixRotation){
+        tempImage = [self rotateImage:tempImage withRotation:rotation];
+    }
 
     UIGraphicsEndImageContext();
     NSData *imageData = UIImageJPEGRepresentation(tempImage, [quality floatValue] / 100.0f );
@@ -117,6 +141,28 @@ static NSInteger count = 0;
     }
 
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (UIImage*) rotateImage:(UIImage*) image withRotation:(int) rotation{
+    CGFloat rot = rotation * M_PI / 180;
+    
+    // Calculate Destination Size
+    CGAffineTransform t = CGAffineTransformMakeRotation(rot);
+    CGRect sizeRect = (CGRect) {.size = image.size};
+    CGRect destRect = CGRectApplyAffineTransform(sizeRect, t);
+    CGSize destinationSize = destRect.size;
+    
+    // Draw image
+    UIGraphicsBeginImageContext(destinationSize);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextTranslateCTM(context, destinationSize.width / 2.0f, destinationSize.height / 2.0f);
+    CGContextRotateCTM(context, rot);
+    [image drawInRect:CGRectMake(-image.size.width / 2.0f, -image.size.height / 2.0f, image.size.width, image.size.height)];
+    
+    // Save image
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return newImage;
 }
 
 @end


### PR DESCRIPTION
Adds a 'fixRotation' boolean option that will check for exif data, and rotate the image accordingly to allow correct orientation in non-exif aware places. 
I had been having issues on iOS with images being in the wrong orientation. It turned out to be that iOS camera uses Exif to tell the displayer which way up to show the image. The <img> tag however, doesn't seem to heed this exif data, so this option circumvents the need.

By default, on Android, the plugin will now add the com.android.support:exifinterface library, using version '27.+'. This can be configured with the ANDROID_EXIFINTERFACES_VERSION argument. 

I don't know if it's best to stick with this latest version, or use an earlier one for compatibility, but either way, it's configurable.

Also added support to Android for Base64 export.