### PR TITLE
Mismatch in ID/Package name causing double addition of plugin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "Plugin for resizing images only with the uri of the image.",
   "cordova": {
-    "id": "info.protonet.imageresizer",
+    "id": "cordova-plugin-image-resizer",
     "platforms": [
       "ios",
       "android"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="info.protonet.imageresizer" version="0.1.1">
+        id="cordova-plugin-image-resizer" version="0.1.1">
   <name>Image Resizer</name>
   <description>Plugin for resizing images only with the uri of the image.</description>
   <author>Joschka Schulz</author>


### PR DESCRIPTION
Mismatch in ID/Package name causing double addition of plugin to package.json. See issue #44