### PR TITLE
Turn to the previously name to avoid bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-plugin-simple-image-resizer",
-  "version": "0.2.0",
+  "name": "cordova-plugin-image-resizer",
+  "version": "0.1.1",
   "description": "Plugin for resizing images only with the uri of the image.",
   "cordova": {
-    "id": "cordova-plugin-simple-image-resizer",
+    "id": "cordova-plugin-image-resizer",
     "platforms": [
       "ios",
       "android"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-simple-image-resizer" version="0.1.1">
+        id="cordova-plugin-image-resizer" version="0.1.1">
   <name>Image Resizer</name>
   <description>Plugin for resizing images only with the uri of the image.</description>
   <author>Joschka Schulz</author>


### PR DESCRIPTION
after your change in name, cordova no longer able to install the plugin automatically... than i turn the name back