### PR TITLE
Adding Removed Import 

### DIFF
--- a/src/android/ImageResizer.java
+++ b/src/android/ImageResizer.java
@@ -185,7 +185,8 @@ public class ImageResizer extends CordovaPlugin {
             if (folderName.contains("/")) {
                 folder = new File(folderName.replace("file://", ""));
             } else {
-                folder = new File(Environment.getExternalStorageDirectory() + "/" + folderName);
+                Context context = this.cordova.getActivity().getApplicationContext();
+                folder          = context.getDir(folderName, context.MODE_PRIVATE);
             }
         }
         boolean success = true;

--- a/src/android/ImageResizer.java
+++ b/src/android/ImageResizer.java
@@ -16,6 +16,7 @@ import org.apache.cordova.camera.FileHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import android.content.Context;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;


### PR DESCRIPTION
The import android.content.Context was removed from 0.1.0 to 0.2.0. Initially I had tested my fix for #42 against the 0.1.0 code which is currently the latest version that comes down from an cordova install/add, I added the import back and tested on Android 8 with 0.2.0 and it works as well.