### PR TITLE
Fix for NSUrl -1022 error for local files

### DIFF
--- a/src/ios/ImageResizer.m
+++ b/src/ios/ImageResizer.m
@@ -30,10 +30,12 @@
     BOOL asBase64 = [[arguments objectForKey:@"base64"] boolValue];
     BOOL fixRotation = [[arguments objectForKey:@"fixRotation"] boolValue];
     
-    //    //Get the image from the path
-    NSURL* imageURL = [NSURL URLWithString:imageUrlString];
-    
-    sourceImage = [UIImage imageWithData: [NSData dataWithContentsOfURL: imageURL]];
+    // Check if the file is a local file, and if so, read with file manager to avoid NSUrl -1022 error
+    if ([[NSFileManager defaultManager] fileExistsAtPath:imageUrlString]){
+        sourceImage = [UIImage imageWithData: [[NSFileManager defaultManager] contentsAtPath:imageUrlString]];
+    }else {
+        sourceImage = [UIImage imageWithData: [NSData dataWithContentsOfURL: [NSURL URLWithString:imageUrlString]]];
+    }    
     
     int rotation = 0;
     


### PR DESCRIPTION
Checks if the file is local, and reads with NSFileManager if it is rather than loading with NSUrl. This negates the need for altering NSAppTransportSecurity settings to allow non-HTTPS URLs.